### PR TITLE
Issue#1: Add scripts to chain multiple repository releases

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,3 @@
+#### What does this PR do?
+#### Who is reviewing it?
+#### How should this be tested?

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,19 @@
- allprojects  {
-   apply plugin: 'maven'
+allprojects {
+    apply plugin: 'groovy'
+    apply plugin: 'maven'
+    apply plugin: 'build-dashboard'
 }
+
 subprojects {
-  repositories {
-    mavenLocal()
-    mavenCentral()
-  }
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
+    test {
+        testLogging {
+            showStandardStreams = true
+            exceptionFormat = 'full'
+        }
+    }
 }

--- a/libera/README.md
+++ b/libera/README.md
@@ -1,0 +1,29 @@
+# Libera
+
+Multi-Project Maven Release Helper script
+
+This script is to help automate the process of releasing multiple projects that depend on each other.
+
+## Building
+This project requires gradle
+
+### Full build
+```bash
+gradle build
+```
+
+distribution files will be under `build/distributions`
+
+### Test build
+to run the build and auto-expand the distribution script run:
+```bash
+gradle installDist
+```
+
+installed distribution will be under `build/install`
+
+## Features
+
+* Supports releasing one or more projects in sequence
+* Automatically updates down-stream projects' pom files to use previous projects' newly released version
+* Uses Libero to release each individual project

--- a/libera/build.gradle
+++ b/libera/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'application'
 
-group = 'com.connexta.libero'
+group = 'com.connexta.libera'
 version = '1.0.0-SNAPSHOT'
 
-mainClassName = 'com.connexta.libero.Cli'
+mainClassName = 'com.connexta.libera.Libera'
 
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.4'
     compile 'org.jyaml:jyaml:1.3'
     compile 'commons-cli:commons-cli:1.3.1'
+    compile project(':libero')
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testCompile 'cglib:cglib-nodep:3.2.2'
+    testCompile 'org.objenesis:objenesis:2.2'
 }

--- a/libera/src/main/groovy/com/connexta/libera/Libera.groovy
+++ b/libera/src/main/groovy/com/connexta/libera/Libera.groovy
@@ -1,0 +1,130 @@
+package com.connexta.libera
+
+import com.connexta.libero.Libero
+import org.apache.commons.cli.MissingArgumentException
+
+/**
+ * Class used to validate and extract the command line options and project arguments.
+ */
+class Arguments {
+    private static final USAGE_HEADER = '''
+        Releases a series of inter-dependent projects.
+
+        conventions:
+          - A <project>.yml file, that contains all the default release
+            configuration for that project, must exit in the current working
+            directory ($CWD).
+          - All projects to release must be cloned under the same parent
+            directory ($CWD/project1, $CWD/project2, etc.).
+          - The script must be run from the common parent directory of the
+            projects' local git repositories ($CWD).
+          - The root pom.xml of each project (excluding the first one) must
+            contain a property named <previous project>.version that will be
+            updated to use the previous projects' version.
+          - The <release-version> argument indicates the version to use when
+            releasing that project and the version that will be used in the
+            pom file of the following project when released.
+
+        example:
+          libera foo:2.9.0-RC4:2.9.1-SNAPSHOT bar:4.3.1-RC3
+
+          Assuming that the current working directory is $CWD, the previous
+          command will release version 2.9.0-RC4 of the foo project using the
+          configuration found in $CWD/foo.yml and the local git repository
+          located in $CWD/foo.
+          It will then update the $CWD/bar/pom.xml file's <foo.version/>
+          property to 2.9.0-RC4 and release version 4.3.1-RC3 of the bar
+          project located in $CWD/bar using the $CWD/bar.yml configuration
+          file.
+          Finally, the script will update the version of foo back to
+          2.9.1-SNAPSHOT (both in the foo repository and the $CWD/bar/pom.xml
+          file), and update the bar version to 4.3.1-SNAPSHOT
+
+        options:
+        '''.stripIndent()
+
+    private CliBuilder cli
+    private OptionAccessor options
+
+    /**
+     * Constructor that accepts the command line arguments and parses them.
+     *
+     * @param args command line arguments
+     */
+    Arguments(args) {
+        cli = new CliBuilder(usage: 'libera [-fhpqt] project1[:release-version[:next-version]] ' +
+                '[project2[:release-version[:next-version]]] ...',
+                header: USAGE_HEADER, stopAtNonOption: false)
+
+        cli.with {
+            f longOpt: 'force', 'Skips confirmation of options and executes the release'
+            h longOpt: 'help', 'Show usage information'
+            p longOpt: 'push', 'Push commits and tags'
+            q longOpt: 'quick-build', 'Executes a quick build instead of a full build (not recommended when not in dry run mode!)'
+            t longOpt: 'test', 'Run in dry run mode'
+        }
+
+        def options = cli.parse(args)
+
+        if (!options) {
+            throw new IllegalArgumentException("Unrecognized option")
+        }
+
+        if (options.h) {
+            cli.usage()
+            throw new MissingArgumentException("Help requested")
+        }
+
+        this.options = options
+    }
+
+    /**
+     * Gets the execution options provided at the command line
+     *
+     * @return execution options
+     */
+    Options getOptions() {
+        return new Options(options)
+    }
+
+    /**
+     * Gets the list of project arguments provided at the command line in the
+     * "<project>[:<releaseVersion>[:<nextVersion>]]" format
+     *
+     * @return project arguments, one for each project to release
+     */
+    List<String> getProjectArguments() {
+        def arguments = options.arguments()
+
+        if (arguments.isEmpty()) {
+            println 'Missing arguments'
+            cli.usage()
+            throw new MissingArgumentException("No projects specified")
+        }
+
+        return arguments
+    }
+}
+
+/**
+ * Main method.
+ *
+ * @param args command line arguments
+ */
+def int run(String[] args) {
+    try {
+        def libero = new Libero()
+        def arguments = new Arguments(args)
+        def firstProject = Project.createProjects(libero, arguments.projectArguments)
+        firstProject.release(arguments.options)
+        return 0
+    } catch (IllegalArgumentException | MissingArgumentException e) {
+        return 1
+    } catch (Exception e) {
+        println "Release failed: ${e.message}"
+        return 2
+    }
+}
+
+// Runs the script
+System.exit(run(args))

--- a/libera/src/main/groovy/com/connexta/libera/Options.groovy
+++ b/libera/src/main/groovy/com/connexta/libera/Options.groovy
@@ -1,0 +1,25 @@
+package com.connexta.libera
+
+/**
+ * Class that encapsulates the release execution options.
+ */
+class Options {
+    final boolean gitPush
+    final boolean dryRun
+    final boolean force
+    final boolean quickBuild
+
+    Options(map) {
+        gitPush = map.gitPush
+        dryRun = map.dryRun
+        force = map.force
+        quickBuild = map.quickBuild
+    }
+
+    Options(OptionAccessor options) {
+        this.gitPush = options.p ?: false
+        this.dryRun = options.t ?: false
+        this.force = options.f ?: false
+        this.quickBuild = options.q ?: false
+    }
+}

--- a/libera/src/main/groovy/com/connexta/libera/Project.groovy
+++ b/libera/src/main/groovy/com/connexta/libera/Project.groovy
@@ -1,0 +1,123 @@
+package com.connexta.libera
+
+import com.connexta.libero.Config
+import com.connexta.libero.Libero
+import groovy.transform.PackageScope
+
+/**
+ * Class that represents a chain of projects to be released. Each project contains a name, a release
+ * version, a next version and a reference to the next project to release.
+ */
+class Project {
+    final Libero libero
+    final String projectName
+    final String releaseVersion
+    final String nextVersion
+    final Project nextProject;
+    Project previousProject = null;
+
+    // Project class that doesn't release anything. Used as the last project in the release chain.
+    @PackageScope
+    static final Project NO_OP_PROJECT = new Project(null, "", null) {
+
+        @Override
+        void release(Options options) {
+            // Last Project in the chain that does nothing and stops the release process
+        }
+    }
+
+    /**
+     * Constructor. Assumes that all input parameters have already been validated.
+     *
+     * @param libero reference to the {@link Libero} object to use to perform the releases
+     * @param projectInfo information about the project to release in the
+     *                    "<project>[:<releaseVersion>[:<nextVersion>]]" format
+     * @param nextProject reference to the next project to release. {@link #NO_OP_PROJECT} must
+     *                    be used if this project is the last one to be released.
+     */
+    protected Project(Libero libero, String projectInfo, Project nextProject) {
+        def strings = projectInfo.tokenize(":")
+
+        this.libero = libero
+        this.projectName = strings[0]
+        this.releaseVersion = strings[1]
+        this.nextVersion = strings[2]
+        this.nextProject = nextProject
+
+        if (nextProject != null && nextProject != NO_OP_PROJECT) {
+            this.nextProject.previousProject = this
+        }
+    }
+
+    /**
+     * Creates {@link Project} instances from a list of project arguments, chaining them and
+     * returning the first one to release.
+     *
+     * @param libero reference to the Libero object used to perform the actual release operations
+     * @param projectArguments list of strings containing the release information about the
+     *                         projects in the "<project>[:<releaseVersion>[:<nextVersion>]]" format
+     * @return reference to the first project to release
+     */
+    static Project createProjects(Libero libero, List<String> projectArguments) {
+        def nextProject = NO_OP_PROJECT
+
+        projectArguments.reverseEach {
+            projectArgument ->
+                nextProject = new Project(libero, projectArgument, nextProject)
+        }
+
+        return nextProject
+    }
+
+    /**
+     * Releases this project. If successful, the next project will automatically be released.
+     *
+     * @param options release options provided at the command line
+     */
+    void release(Options options) {
+        doRelease(options, getConfig())
+    }
+
+    protected Config loadConfig() {
+        def config = new Config();
+        config.configFile = new File("${projectName}.yml")
+        config.loadConfig()
+        return config
+    }
+
+    private doRelease(Options options, Config config) {
+        config.force = options.force
+        config.gitPush = options.gitPush
+        config.dryRun = options.dryRun
+        config.quickBuild = options.quickBuild
+
+        println "Releasing project ${projectName} ${releaseVersion} using the following configuration:"
+        config.printConfig()
+
+        libero.run(config)
+        nextProject.release(options)
+    }
+
+    private getConfig() {
+        def config = loadConfig()
+
+        config.projectName = projectName
+        config.releaseVersion = releaseVersion
+        config.nextVersion = nextVersion ?: config.nextVersion
+        config.projectDir = System.getProperty('user.dir') + File.separator + projectName
+
+        config.preProps = [:]
+        config.postProps = [:]
+        addPreAndPostVersions(config)
+
+        return config
+    }
+
+    protected addPreAndPostVersions(Config config) {
+        if (previousProject != null && previousProject != NO_OP_PROJECT) {
+            config.preProps.put("${previousProject.projectName}.version", "${previousProject.releaseVersion}")
+            config.postProps.put("${previousProject.projectName}.version", "${previousProject.nextVersion}")
+            previousProject.addPreAndPostVersions(config)
+        }
+    }
+}

--- a/libera/src/test/groovy/com/connexta/libera/TestLibera.groovy
+++ b/libera/src/test/groovy/com/connexta/libera/TestLibera.groovy
@@ -1,0 +1,97 @@
+package com.connexta.libera
+
+import com.connexta.libero.Libero
+import spock.lang.Specification
+
+class TestLibera extends Specification {
+    def libera = new Libera()
+
+    def "Run creates projects and starts release"() {
+        given:
+        GroovyMock(Project, global: true)
+        def arguments = GroovyMock(Arguments, global: true)
+        def projects = Mock(Project)
+        def options = Mock(Options)
+
+        def args = ["project1:1.0.0:2.0.0", "project2:1.1.0:1.2.0"] as String[]
+        def projectInfo = ["project1:1.0.0:2.0.0", "project2:1.1.0:1.2.0"]
+
+        when:
+        new Arguments(args) >> arguments
+        arguments.projectArguments >> projectInfo
+        arguments.options >> options
+        Project.createProjects(_ as Libero, _ as List<String>) >> projects
+        def exitCode = libera.run(args)
+
+        then:
+        1 * projects.release(options)
+        exitCode == 0
+    }
+
+    def "Run returns error exit code when release fails"() {
+        given:
+        GroovyMock(Project, global: true)
+        def projects = Mock(Project)
+
+        when:
+        Project.createProjects(_ as Libero, _ as List<String>) >> projects
+        projects.release(_) >> { throw new Exception() }
+        def exitCode = libera.run(["project:1.0.0:2.0.0"] as String[])
+
+        then:
+        exitCode == 2
+    }
+
+    def "Run with invalid arguments returns error exit code"() {
+        given:
+        GroovyMock(Project, global: true)
+
+        when:
+        def exitCode = libera.run(["-h"] as String[])
+
+        then:
+        exitCode == 1
+        0 * Project.createProjects(_, _)
+    }
+
+    def "Run with no projects returns error exit code"() {
+        given:
+        GroovyMock(Project, global: true)
+
+        when:
+        def exitCode = libera.run(["-fpqt"] as String[])
+
+        then:
+        exitCode == 1
+        0 * Project.createProjects(_, _)
+    }
+
+    def "Run works with all supported options"() {
+        given:
+        GroovyMock(Project, global: true)
+        def projects = Mock(Project)
+        Project.createProjects(_ as Libero, _ as List<String>) >> projects
+
+        expect:
+        libera.run(args) == 0
+
+        where:
+        args                                      | _
+        ["-f", "project:1.0.0:2.0.0"] as String[] | _
+        ["-p", "project:1.0.0:2.0.0"] as String[] | _
+        ["-q", "project:1.0.0:2.0.0"] as String[] | _
+        ["-t", "project:1.0.0:2.0.0"] as String[] | _
+    }
+
+    def "Run with unsupported options returns error exit code"() {
+        given:
+        GroovyMock(Project, global: true)
+
+        when:
+        def exitCode = libera.run(["--invalid"] as String[])
+
+        then:
+        exitCode == 1
+        0 * Project.createProjects(_, _)
+    }
+}

--- a/libera/src/test/groovy/com/connexta/libera/TestOptions.groovy
+++ b/libera/src/test/groovy/com/connexta/libera/TestOptions.groovy
@@ -1,0 +1,38 @@
+package com.connexta.libera
+
+import spock.lang.Specification
+
+class TestOptions extends Specification {
+
+    def "Options properly initialized when all command line flags have been set"() {
+        setup:
+        def optionAccessor = Mock(OptionAccessor)
+
+        when:
+        optionAccessor.getProperty('f') >> true
+        optionAccessor.getProperty('p') >> true
+        optionAccessor.getProperty('q') >> true
+        optionAccessor.getProperty('t') >> true
+
+        then:
+        def options = new Options(optionAccessor)
+        options.force
+        options.gitPush
+        options.quickBuild
+        options.dryRun
+    }
+
+    def "Options properly initialized when no command line flags have been set"() {
+        setup:
+        def optionAccessor = Mock(OptionAccessor)
+
+        when:
+        def options = new Options(optionAccessor)
+
+        then:
+        !options.force
+        !options.gitPush
+        !options.quickBuild
+        !options.dryRun
+    }
+}

--- a/libera/src/test/groovy/com/connexta/libera/TestProject.groovy
+++ b/libera/src/test/groovy/com/connexta/libera/TestProject.groovy
@@ -1,0 +1,214 @@
+package com.connexta.libera
+
+import com.connexta.libero.Config
+import com.connexta.libero.Libero
+import spock.lang.Specification
+
+import static com.connexta.libera.Project.NO_OP_PROJECT
+
+class TestProject extends Specification {
+    def libero = Mock(Libero)
+
+    def project1 = [name: "project1", releaseVersion: "1.0.0", nextVersion: "1.1.0"]
+    def project2 = [name: "project2", releaseVersion: "2.0.0", nextVersion: "2.1.0"]
+    def project3 = [name: "project3", releaseVersion: "3.0.0", nextVersion: "3.1.0"]
+
+    class ProjectUnderTest extends Project {
+        Config config = new Config(
+                configFile: new File(getClass().getResource("/project.yml").toURI()))
+
+        ProjectUnderTest(Libero libero, String projectInfo, Project nextProject) {
+            super(libero, projectInfo, nextProject)
+        }
+
+        @Override
+        protected Config loadConfig() {
+            config.loadConfig()
+            return config
+        }
+    }
+
+    def "Create list of projects when no declaration provided"() {
+        given:
+        def emptyProjectDeclarationList = []
+
+        when:
+        def projects = Project.createProjects(libero, emptyProjectDeclarationList)
+
+        then:
+        projects == NO_OP_PROJECT
+    }
+
+    def "Create list of projects from multiple declarations"() {
+        given:
+        def projectDeclarations = [
+                "${project1.name}:${project1.releaseVersion}:${project1.nextVersion}",
+                "${project2.name}:${project2.releaseVersion}:${project2.nextVersion}"
+        ]
+
+        when:
+        def projects = Project.createProjects(libero, projectDeclarations)
+
+        then:
+        def firstProject = projects
+        firstProject.projectName == project1.name
+        firstProject.releaseVersion == project1.releaseVersion
+        firstProject.nextVersion == project1.nextVersion
+
+        def secondProject = firstProject.nextProject
+        secondProject.projectName == project2.name
+        secondProject.releaseVersion == project2.releaseVersion
+        secondProject.nextVersion == project2.nextVersion
+        secondProject.previousProject == firstProject
+        secondProject.nextProject == NO_OP_PROJECT
+    }
+
+    def "Create Project with only a project name"() {
+        given:
+
+        when:
+        def project = new Project(libero, project1.name, NO_OP_PROJECT)
+
+        then:
+        project.projectName == project1.name
+        !project.releaseVersion
+        !project.nextVersion
+    }
+
+    def "Create Project with a project name and release version"() {
+        given:
+
+        when:
+        def project = new Project(libero, "${project1.name}:${project1.releaseVersion}", NO_OP_PROJECT)
+
+        then:
+        project.projectName == project1.name
+        project.releaseVersion == project1.releaseVersion
+        !project.nextVersion
+    }
+
+    def "Create Project with a project name, release version and next version"() {
+        given:
+
+        when:
+        def project =
+                new Project(libero,
+                        "${project1.name}:${project1.releaseVersion}:${project1.nextVersion}",
+                        NO_OP_PROJECT)
+
+        then:
+        project.projectName == project1.name
+        project.releaseVersion == project1.releaseVersion
+        project.nextVersion == project1.nextVersion
+    }
+
+    def "Libero and next project are set in Project"() {
+        given:
+        def nextProject = Mock(Project)
+
+        when:
+        def project = new Project(libero, project1.name, nextProject)
+
+        then:
+        project.libero == libero
+        project.nextProject == nextProject
+    }
+
+    def "Release options are added to the Config object"() {
+        given:
+        def options = new Options([dryRun: true, force: true, gitPush: true, quickBuild: true])
+        def project = new ProjectUnderTest(libero, "project", NO_OP_PROJECT)
+
+        when:
+        project.release(options)
+
+        then:
+        project.config.dryRun
+        project.config.force
+        project.config.gitPush
+        project.config.quickBuild
+    }
+
+    def "Release single project"() {
+        given:
+        def project =
+                new ProjectUnderTest(libero,
+                        "${project1.name}:${project1.releaseVersion}:${project1.nextVersion}",
+                        NO_OP_PROJECT)
+
+        when:
+        project.release(Mock(Options))
+
+        then:
+        // Not sure why but libero.run(config) didn't work here...
+        // libero.run(project.config)
+        libero.run(project.config) >> { Config c -> c == project.config }
+        project.config.projectDir == System.getProperty('user.dir') + File.separator + project1.name
+        project.config.releaseVersion == project1.releaseVersion
+        project.config.nextVersion == project1.nextVersion
+        !project.config.preProps
+        !project.config.postProps
+    }
+
+    def "Projects are properly chained"() {
+        given:
+        def firstProject = Project.createProjects(libero, [
+                "${project1.name}:${project1.releaseVersion}:${project1.nextVersion}",
+                "${project2.name}:${project2.releaseVersion}:${project2.nextVersion}",
+                "${project3.name}:${project3.releaseVersion}:${project3.nextVersion}"
+        ])
+
+        def secondProject = firstProject.nextProject
+        def thirdProject = secondProject.nextProject
+
+        expect:
+        thirdProject.nextProject == NO_OP_PROJECT
+        thirdProject.previousProject == secondProject
+        secondProject.previousProject == firstProject
+        firstProject.previousProject == null
+    }
+
+    def "Release multiple projects"() {
+        given:
+        def thirdProject =
+                new ProjectUnderTest(libero,
+                        "${project3.name}:${project3.releaseVersion}:${project3.nextVersion}",
+                        NO_OP_PROJECT)
+
+        def secondProject =
+                new ProjectUnderTest(libero,
+                        "${project2.name}:${project2.releaseVersion}:${project2.nextVersion}",
+                        thirdProject)
+
+        def firstProject =
+                new ProjectUnderTest(libero,
+                        "${project1.name}:${project1.releaseVersion}:${project1.nextVersion}",
+                        secondProject)
+
+        when:
+        firstProject.release(Mock(Options))
+
+        then:
+        libero.run(firstProject.config) >> { Config c -> c == firstProject.config }
+        libero.run(secondProject.config) >> { Config c -> c == secondProject.config }
+        libero.run(thirdProject.config) >> { Config c -> c == thirdProject.config }
+
+        secondProject.config.projectDir == System.getProperty('user.dir') + File.separator + project2.name
+        secondProject.config.releaseVersion == project2.releaseVersion
+        secondProject.config.nextVersion == project2.nextVersion
+        secondProject.config.preProps == ["${project1.name}.version": "${project1.releaseVersion}"]
+        secondProject.config.postProps == ["${project1.name}.version": "${project1.nextVersion}"]
+
+        thirdProject.config.projectDir == System.getProperty('user.dir') + File.separator + project3.name
+        thirdProject.config.releaseVersion == project3.releaseVersion
+        thirdProject.config.nextVersion == project3.nextVersion
+        thirdProject.config.preProps == [
+                "${project1.name}.version": "${project1.releaseVersion}",
+                "${project2.name}.version": "${project2.releaseVersion}"
+        ]
+        thirdProject.config.postProps == [
+                "${project1.name}.version": "${project1.nextVersion}",
+                "${project2.name}.version": "${project2.nextVersion}"
+        ]
+    }
+}

--- a/libera/src/test/resources/project.yml
+++ b/libera/src/test/resources/project.yml
@@ -1,0 +1,18 @@
+project:
+  git:
+    source:
+      remote: "origin"
+      ref: "master"
+    destination:
+      remote: "origin"
+      branch: "master"
+      push: false
+  maven:
+    repo: "foo::default::https://bar.baz/nexus/content/repositories/releases/"
+    quickbuild: false
+  settings:
+    dryRun: false
+    force: false
+  versions:
+    release: ""
+    development: ""

--- a/libero/src/main/groovy/com/connexta/libero/Config.groovy
+++ b/libero/src/main/groovy/com/connexta/libero/Config.groovy
@@ -24,7 +24,7 @@ class Config {
     boolean force
     Util util = new Util()
 
-    public loadConfig = { ->
+    def loadConfig() {
         def project = load(configFile).project
 
         // Git settings
@@ -53,13 +53,14 @@ class Config {
         resolveProperties()
     }
 
-    public printConfig = { ->
+    def printConfig() {
         println "============== RELEASE PARAMETERS =============="
         println "____________ GENERAL ____________"
         println "Project Directory: ${projectDir}"
         println "Project Name: ${projectName}"
         println "Config File: ${configFile}"
         println "Dry Run: ${dryRun}"
+        println "Force: ${force}"
         println "______________ GIT ______________"
         println "Source git Remote: ${sourceRemote}"
         println "Source git Ref: ${ref}"

--- a/libero/src/main/groovy/com/connexta/libero/Libero.groovy
+++ b/libero/src/main/groovy/com/connexta/libero/Libero.groovy
@@ -15,25 +15,13 @@ import java.text.SimpleDateFormat
 
 class Libero {
 
-    Config config
     Util util
 
     Libero() {
-        this.config = new Config()
         this.util = new Util()
     }
 
-    Libero(Config config) {
-        this.config = config
-    }
-
-    Libero(Config config, Util util) {
-        this.config = config
-        this.util = util
-    }
-
-    def run = { ->
-
+    def run(Config config) {
         Date date = new Date()
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         config.projectProperties.date = date
@@ -56,8 +44,7 @@ class Libero {
                     println "Response must be either [y/n]"
                     System.exit(1)
             }
-        }
-        else {
+        } else {
             executeRelease(config)
         }
     }
@@ -66,7 +53,7 @@ class Libero {
      * Executes the build and deploy of the release
      * @param config Libero configuration
      */
-    def runBuild(Config config) {
+    private def runBuild(Config config) {
         String gitCommand = "git"
         String gitCheckoutCommand = "${gitCommand} checkout ${config.releaseName}"
         String gitPushCommand = "${gitCommand} push ${config.destRemote}"
@@ -81,8 +68,7 @@ class Libero {
 
         if (config.quickBuild) {
             buildCommand = "${mavenCommand} ${quickBuildParams} clean install"
-        }
-        else {
+        } else {
             buildCommand = "${mavenCommand} clean install"
         }
         util.executeCommand(buildCommand, config.projectDir)
@@ -108,7 +94,7 @@ class Libero {
      * @param config Libero Configuration
      * @return
      */
-    def executeRelease(Config config) {
+    private def executeRelease(Config config) {
         prepareRelease(config)
         runBuild(config)
     }
@@ -118,7 +104,7 @@ class Libero {
      * @param config Libero config
      * @return
      */
-    def prepareRelease(Config config) {
+    private def prepareRelease(Config config) {
 
         // Define Commands
         String gitCommand = "git"
@@ -142,7 +128,7 @@ class Libero {
         util.executeCommand(mavenCommitVersionCommand, config.projectDir)
 
         // Pre-Release property updates
-        config.preProps.each{ k, v ->
+        config.preProps.each { k, v ->
             util.executeCommand("sed -i '' \"s|<${k}>[^<>]*</${k}>|<${k}>${v}</${k}>|g\" pom.xml", config.projectDir)
         }
         util.executeCommand(gitAddCommand, config.projectDir)
@@ -151,7 +137,7 @@ class Libero {
         util.executeCommand(setDevVersionCommand, config.projectDir)
         util.executeCommand(mavenCommitVersionCommand, config.projectDir)
         // Post-Release property updates
-        config.postProps.each{ k, v ->
+        config.postProps.each { k, v ->
             util.executeCommand("sed -i '' \"s|<${k}>[^<>]*</${k}>|<${k}>${v}</${k}>|g\" pom.xml", config.projectDir)
         }
         util.executeCommand(gitAddCommand, config.projectDir)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'libero-all'
 include 'libero'
+include 'libera'
 
 project(':libero').projectDir = "$rootDir/libero" as File
+project(':libera').projectDir = "$rootDir/libera" as File


### PR DESCRIPTION
#### What does this PR do?

fixes #1 
Script that releases multiple projects in one go. Includes a few fixes to the Libero script. Also, because of a current limitation in the Libero script, this initial version requires the next version of every project to be specified.
#### Who is reviewing it?

@oconnormi @LinkMJB 
#### How should this be tested?

Create project specific `yml` files and run script to release multiple projects.
